### PR TITLE
dev: new: added LogUniform to distributions.py

### DIFF
--- a/src/modelbase2/distributions.py
+++ b/src/modelbase2/distributions.py
@@ -7,6 +7,7 @@ Classes:
     Distribution (Protocol): Base protocol for all distribution classes
     Beta: Beta distribution for parameters bounded between 0 and 1
     Uniform: Uniform distribution for parameters with simple bounds
+    LogUniform: LogUniform distribution for parameters with simple bounds
     Normal: Normal (Gaussian) distribution for unbounded parameters
     LogNormal: Log-normal distribution for strictly positive parameters
     Skewnorm: Skewed normal distribution for asymmetric parameter distributions
@@ -35,6 +36,7 @@ __all__ = [
     "Distribution",
     "GaussianKde",
     "LogNormal",
+    "LogUniform",
     "Normal",
     "RNG",
     "Skewnorm",
@@ -119,6 +121,34 @@ class Uniform:
         if rng is None:
             rng = RNG
         return rng.uniform(self.lower_bound, self.upper_bound, num)
+
+
+@dataclass
+class LogUniform:
+    """LogUniform distribution for parameters with simple bounds.
+
+    Args:
+        lower_bound: Minimum value
+        upper_bound: Maximum value
+
+    """
+
+    lower_bound: float
+    upper_bound: float
+
+    def sample(self, num: int, rng: np.random.Generator | None = None) -> Array:
+        """Generate random samples from the loguniform distribution.
+
+        Args:
+            num: Number of samples to generate
+            rng: Random number generator
+
+        """
+        if rng is None:
+            rng = RNG
+        return stats.loguniform.rvs(
+            self.lower_bound, self.upper_bound, size=num, random_state=rng
+        )
 
 
 @dataclass


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the contribution guideline: https://github.com/Computational-Biology-Aachen/modelbase2/blob/main/CONTRIBUTING.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ If applicable provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I added a LogUniform distrubution to the distribution files 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #16 

## QA Instructions, Screenshots, Recordings

Usage is same as with the other distributions

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests 

## Added/updated documentation

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why documentation has not been updated
- [x] I need help with writing documentation

## Checked Coding standard
- [x] Named functions according to [pep8](http://pep8.org/)
- [x] Used pre-commit [pre-commit](https://pre-commit.com/)
  



